### PR TITLE
Fix speech bubble tail rendering and export

### DIFF
--- a/export_manager.py
+++ b/export_manager.py
@@ -988,10 +988,26 @@ class ExportManager:
                     
                 # Координаты и размеры панели на экспортном холсте (в пикселях)
                 # Сначала масштабируем относительно экспортной области, затем добавляем смещение вылетов
-                panel_export_x = int(panel.x * scale_content_x) + offset_x_bleed_px
-                panel_export_y = int(panel.y * scale_content_y) + offset_y_bleed_px
-                panel_export_w = int(panel.width * scale_content_x)
-                panel_export_h = int(panel.height * scale_content_y)
+                px1, py1 = panel.x, panel.y
+                px2, py2 = panel.x + panel.width, panel.y + panel.height
+
+                if panel.panel_type == PanelType.SPEECH_BUBBLE:
+                    cx = panel.x + panel.width / 2
+                    cy = panel.y + panel.height / 2
+                    angle = getattr(panel, 'tail_root_angle', math.pi / 2)
+                    rx = cx + (panel.width / 2) * math.cos(angle) + panel.tail_dx
+                    ry = cy + (panel.height / 2) * math.sin(angle) + panel.tail_dy
+                    px1 = min(px1, rx)
+                    py1 = min(py1, ry)
+                    px2 = max(px2, rx)
+                    py2 = max(py2, ry)
+
+                panel_export_x = int(px1 * scale_content_x) + offset_x_bleed_px
+                panel_export_y = int(py1 * scale_content_y) + offset_y_bleed_px
+                panel_export_w = int((px2 - px1) * scale_content_x)
+                panel_export_h = int((py2 - py1) * scale_content_y)
+                offset_inside_x = int((panel.x - px1) * scale_content_x)
+                offset_inside_y = int((panel.y - py1) * scale_content_y)
 
                 if panel_export_w <=0 or panel_export_h <=0: 
                     continue # Пропускаем нулевые или отрицательные размеры
@@ -1000,11 +1016,18 @@ class ExportManager:
                 # Это отношение целевого DPI к "базовому DPI" панелей (который теперь 300 DPI).
                 detail_scale_factor = target_dpi / REFERENCE_DPI_FOR_PAGE_SIZES 
 
-                self.render_panel_to_image(draw, panel, 
-                                           (panel_export_x, panel_export_y, 
-                                            panel_export_x + panel_export_w, panel_export_y + panel_export_h), 
-                                           detail_scale_factor,
-                                           export_target_image=image) # Передаем целевое изображение для PIL paste
+                self.render_panel_to_image(
+                    draw,
+                    panel,
+                    (panel_export_x, panel_export_y,
+                     panel_export_x + panel_export_w, panel_export_y + panel_export_h),
+                    detail_scale_factor,
+                    export_target_image=image,
+                    scale_x=scale_content_x,
+                    scale_y=scale_content_y,
+                    offset_x_px=offset_inside_x,
+                    offset_y_px=offset_inside_y,
+                )
 
             # --- 4. Добавление меток (если включены) ---
             # Здесь export_page_width_px и export_page_height_px - это размеры обрезной страницы
@@ -1028,7 +1051,12 @@ class ExportManager:
             panel: Panel,
             bounds: Tuple[int, int, int, int],
             scale_factor: float,                        # target_dpi / REFERENCE_DPI
-            export_target_image: Image.Image
+            export_target_image: Image.Image,
+            *,
+            scale_x: float,
+            scale_y: float,
+            offset_x_px: int = 0,
+            offset_y_px: int = 0,
     ):
         """
         Рендерит одну панель страницы на итоговый export-canvas.
@@ -1038,69 +1066,83 @@ class ExportManager:
         """
 
         x1_panel, y1_panel, x2_panel, y2_panel = bounds
-        panel_w_px = x2_panel - x1_panel
-        panel_h_px = y2_panel - y1_panel
-        if panel_w_px <= 0 or panel_h_px <= 0:
+        buf_w = x2_panel - x1_panel
+        buf_h = y2_panel - y1_panel
+        if buf_w <= 0 or buf_h <= 0:
             return
 
-        # ────────────────────────── буфер панели ──────────────────────────
-        panel_buf = Image.new("RGBA", (panel_w_px, panel_h_px), (0, 0, 0, 0))
+        panel_buf = Image.new("RGBA", (buf_w, buf_h), (0, 0, 0, 0))
+
+        panel_w_px = int(panel.width * scale_x)
+        panel_h_px = int(panel.height * scale_y)
 
         # 1. фон
         if panel.style.fill_color and panel.style.fill_color.lower() != "transparent":
             try:
                 panel_buf.paste(
-                    Image.new("RGBA", (panel_w_px, panel_h_px), panel.style.fill_color),
+                    Image.new("RGBA", (buf_w, buf_h), panel.style.fill_color),
                     (0, 0)
                 )
             except ValueError:
                 logger.warning(f"Некорректный цвет фона '{panel.style.fill_color}' у панели {panel.id}")
 
         # 2. изображение-контент
-        self._render_panel_image_content(panel, panel_buf, panel_w_px, panel_h_px)
+        self._render_panel_image_content(
+            panel, panel_buf, panel_w_px, panel_h_px, origin_x=offset_x_px, origin_y=offset_y_px
+        )
 
         # 3. маска базовой формы (овал или прямоугольник)
-        mask = Image.new("L", (panel_w_px, panel_h_px), 0)
+        mask = Image.new("L", (buf_w, buf_h), 0)
         mdraw = ImageDraw.Draw(mask)
         if panel.panel_type in (PanelType.ROUND,
                                 PanelType.SPEECH_BUBBLE,
                                 PanelType.THOUGHT_BUBBLE):
-            mdraw.ellipse((0, 0, panel_w_px, panel_h_px), fill=255)
+            mdraw.ellipse(
+                (offset_x_px, offset_y_px,
+                 offset_x_px + panel_w_px, offset_y_px + panel_h_px),
+                fill=255)
         else:
-            mdraw.rectangle((0, 0, panel_w_px, panel_h_px), fill=255)
+            mdraw.rectangle(
+                (offset_x_px, offset_y_px,
+                 offset_x_px + panel_w_px, offset_y_px + panel_h_px),
+                fill=255)
 
         # 3-a. хвост речевого пузыря
         if panel.panel_type == PanelType.SPEECH_BUBBLE:
-            # коэффициенты «единица страницы → пиксели» для данной панели
-            sx = panel_w_px / panel.width  if panel.width  else 1.0
-            sy = panel_h_px / panel.height if panel.height else 1.0
+            angle = getattr(panel, 'tail_root_angle', math.pi / 2)
+            cx = offset_x_px + panel_w_px / 2
+            cy = offset_y_px + panel_h_px / 2
+            root_x_px = cx + (panel_w_px / 2) * math.cos(angle)
+            root_y_px = cy + (panel_h_px / 2) * math.sin(angle)
+            end_x_px = root_x_px + panel.tail_dx * scale_x
+            end_y_px = root_y_px + panel.tail_dy * scale_y
 
-            root_x_px = int((panel.width / 2 + panel.tail_root_offset) * sx)
-            root_y_px = int(panel.height * sy)
-            end_x_px  = int((panel.width / 2 + panel.tail_root_offset + panel.tail_dx) * sx)
-            end_y_px  = int((panel.height + panel.tail_dy) * sy)
-            base_px   = int(12 * sx)
+            tang_dx = -math.sin(angle) * panel_w_px
+            tang_dy = math.cos(angle) * panel_h_px
+            norm = math.hypot(tang_dx, tang_dy)
+            if norm == 0:
+                tang_dx, tang_dy = 1, 0
+            else:
+                tang_dx /= norm
+                tang_dy /= norm
+
+            base_px = int(6 * max(scale_x, scale_y))
+            bx1 = root_x_px + tang_dx * base_px
+            by1 = root_y_px + tang_dy * base_px
+            bx2 = root_x_px - tang_dx * base_px
+            by2 = root_y_px - tang_dy * base_px
 
             # маска (чтобы хвост вырезался в ту же альфа-область)
-            mdraw.polygon(
-                (root_x_px - base_px, root_y_px,
-                 root_x_px + base_px, root_y_px,
-                 end_x_px, end_y_px),
-                fill=255
-            )
+            mdraw.polygon((bx1, by1, bx2, by2, end_x_px, end_y_px), fill=255)
 
             # сам хвост
             panel_draw = ImageDraw.Draw(panel_buf)
             border_w   = max(1, int(panel.style.border_width * scale_factor)) \
                 if panel.style.border_width > 0 else 0
-            panel_draw.polygon(
-                (root_x_px - base_px, root_y_px,
-                 root_x_px + base_px, root_y_px,
-                 end_x_px, end_y_px),
-                fill=panel.style.fill_color,
-                outline=panel.style.border_color if border_w else None,
-                width=border_w
-            )
+            panel_draw.polygon((bx1, by1, bx2, by2, end_x_px, end_y_px),
+                               fill=panel.style.fill_color,
+                               outline=panel.style.border_color if border_w else None,
+                               width=border_w)
 
         # 4. объединяем маску и буфер
         panel_buf.putalpha(mask)
@@ -1108,9 +1150,16 @@ class ExportManager:
         # 5. вставляем панель на общий экспорт-canvas
         export_target_image.paste(panel_buf, (x1_panel, y1_panel), panel_buf)
 
+        text_bounds = (
+            x1_panel + offset_x_px,
+            y1_panel + offset_y_px,
+            x1_panel + offset_x_px + panel_w_px,
+            y1_panel + offset_y_px + panel_h_px,
+        )
+
         # 6. текст
         if panel.content_text:
-            self.render_panel_text(draw, panel, bounds, scale_factor)
+            self.render_panel_text(draw, panel, text_bounds, scale_factor)
 
         # 7. внешняя рамка панели
         border_w = max(1, int(panel.style.border_width * scale_factor)) \
@@ -1120,11 +1169,45 @@ class ExportManager:
                 if panel.panel_type in (PanelType.ROUND,
                                         PanelType.SPEECH_BUBBLE,
                                         PanelType.THOUGHT_BUBBLE):
-                    draw.ellipse(bounds, outline=panel.style.border_color, width=border_w)
+                    draw.ellipse(text_bounds, outline=panel.style.border_color, width=border_w)
                 else:
-                    draw.rectangle(bounds, outline=panel.style.border_color, width=border_w)
+                    draw.rectangle(text_bounds, outline=panel.style.border_color, width=border_w)
             except ValueError:
                 logger.warning(f"Некорректный цвет рамки '{panel.style.border_color}' у панели {panel.id}")
+
+    def _render_panel_image_content(
+            self,
+            panel: Panel,
+            panel_buf: Image.Image,
+            panel_w_px: int,
+            panel_h_px: int,
+            *,
+            origin_x: int = 0,
+            origin_y: int = 0,
+    ) -> None:
+        """Отрисовка изображения внутри панели на временный буфер."""
+        if not panel.content_image or not os.path.exists(panel.content_image):
+            return
+
+        try:
+            src = Image.open(panel.content_image)
+        except Exception as e:
+            logger.error(f"Не удалось открыть изображение панели {panel.id}: {e}")
+            return
+
+        sx = panel_w_px / panel.width if panel.width else 1.0
+        sy = panel_h_px / panel.height if panel.height else 1.0
+
+        render_w = int(src.width * panel.image_scale * sx)
+        render_h = int(src.height * panel.image_scale * sy)
+        if render_w <= 0 or render_h <= 0:
+            return
+
+        img_resized = src.resize((render_w, render_h), Image.Resampling.LANCZOS)
+        offset_x_px = int(panel.image_offset_x * sx) + origin_x
+        offset_y_px = int(panel.image_offset_y * sy) + origin_y
+
+        panel_buf.paste(img_resized, (offset_x_px, offset_y_px))
             
     def render_panel_text(self, draw: ImageDraw.Draw, panel: Panel, 
                          bounds: Tuple[int, int, int, int], scale_factor: float):

--- a/page_constructor.py
+++ b/page_constructor.py
@@ -69,6 +69,10 @@ class Panel:
     tail_dy: float = 20.0
 
     tail_root_offset: float = 0.0
+
+    # Угол положения основания хвоста относительно центра овала (радианы).
+    # pi/2 соответствует нижней точке, т.е. хвост снизу по умолчанию.
+    tail_root_angle: float = math.pi / 2
     
     # Для неправильных форм - список точек
     custom_points: List[Tuple[float, float]] = field(default_factory=list)
@@ -146,6 +150,9 @@ class PageConstructor:
 
         self.creation_panel_type: Optional[PanelType] = None
         self.tail_move_panel: Optional[Panel] = None
+        self.tail_root_move_panel: Optional[Panel] = None
+        self.tail_root_drag_end_x: float = 0.0
+        self.tail_root_drag_end_y: float = 0.0
         
         # Настройки страницы
         self.page_width = 595
@@ -906,36 +913,61 @@ class PageConstructor:
         # 1) основной овал
         self.draw_round_panel(panel)
 
-        # 2) точка крепления хвоста (центр нижней стороны овала)
-        x1_s, y1_s = self.page_to_screen(panel.x,               panel.y)
-        x2_s, y2_s = self.page_to_screen(panel.x + panel.width, panel.y + panel.height)
-        root_x, root_y = (x1_s + x2_s) / 2, y2_s
+        # 2) точка крепления хвоста
+        center_x = panel.x + panel.width / 2
+        center_y = panel.y + panel.height / 2
 
-        # 3) кончик хвоста с учётом dx/dy
-        end_x = root_x + panel.tail_dx
-        end_y = root_y + panel.tail_dy
+        root_angle = getattr(panel, 'tail_root_angle', math.pi / 2)
+        root_page_x = center_x + (panel.width / 2) * math.cos(root_angle)
+        root_page_y = center_y + (panel.height / 2) * math.sin(root_angle)
+
+        root_x, root_y = self.page_to_screen(root_page_x, root_page_y)
+
+        # 2. кончик хвоста (учитываем dx/dy в единицах страницы)
+        end_page_x = root_page_x + panel.tail_dx
+        end_page_y = root_page_y + panel.tail_dy
+        end_x, end_y = self.page_to_screen(end_page_x, end_page_y)
 
         # 4) стиль
         outline = "#FF6B6B" if panel.selected else panel.style.border_color
         bw      = max(1, int(panel.style.border_width * self.zoom))
 
-        # 5) треугольник-хвост
+        # 5) треугольник-хвост с ориентацией по касательной к овалу
+        tang_dx = -math.sin(root_angle) * panel.width
+        tang_dy =  math.cos(root_angle) * panel.height
+        norm = math.hypot(tang_dx, tang_dy)
+        if norm == 0:
+            tang_dx, tang_dy = 1, 0
+        else:
+            tang_dx /= norm
+            tang_dy /= norm
+
+        base = 5 * self.zoom
+        x1 = root_x + tang_dx * base
+        y1 = root_y + tang_dy * base
+        x2 = root_x - tang_dx * base
+        y2 = root_y - tang_dy * base
+
         self.canvas.create_polygon(
-            root_x - 5 * self.zoom, root_y,
-            root_x + 5 * self.zoom, root_y,
-            end_x, end_y,
+            x1, y1, x2, y2, end_x, end_y,
             fill=panel.style.fill_color,
             outline=outline,
             width=bw,
             tags=(f"panel_{panel.id}_tail", f"panel_{panel.id}_handle")
         )
 
-        # 6) круг-хэндл
-        r = 4 * self.zoom
+        # 6) круг-хэндлы
+        r = max(4, 6 * self.zoom)
         self.canvas.create_oval(
             end_x - r, end_y - r, end_x + r, end_y + r,
             fill=outline, outline="",
             tags=(f"panel_{panel.id}_tail_handle", f"panel_{panel.id}_handle")
+        )
+
+        self.canvas.create_oval(
+            root_x - r, root_y - r, root_x + r, root_y + r,
+            fill=outline, outline="",
+            tags=(f"panel_{panel.id}_tail_root_handle", f"panel_{panel.id}_handle")
         )
 
         # 7) текст (если есть)
@@ -1094,6 +1126,21 @@ class PageConstructor:
                     self.dragging  = True
                     return
 
+            hit, pid = self.clicked_canvas_item_has_tag(event.x, event.y, "_tail_root_handle")
+            if hit and pid:
+                self.tail_root_move_panel = next((p for p in self.panels if p.id == pid), None)
+                if self.tail_root_move_panel:
+                    self.drag_mode = "move_tail_root"
+                    self.dragging  = True
+                    angle = getattr(self.tail_root_move_panel, 'tail_root_angle', math.pi / 2)
+                    cx = self.tail_root_move_panel.x + self.tail_root_move_panel.width / 2
+                    cy = self.tail_root_move_panel.y + self.tail_root_move_panel.height / 2
+                    rx = cx + (self.tail_root_move_panel.width / 2) * math.cos(angle)
+                    ry = cy + (self.tail_root_move_panel.height / 2) * math.sin(angle)
+                    self.tail_root_drag_end_x = rx + self.tail_root_move_panel.tail_dx
+                    self.tail_root_drag_end_y = ry + self.tail_root_move_panel.tail_dy
+                    return
+
             # 1-b. resize-handle?
             if self.selected_panels:
                 cx, cy = self.canvas.canvasx(event.x), self.canvas.canvasy(event.y)
@@ -1174,10 +1221,30 @@ class PageConstructor:
         # 3-a. перетягиваем хвост речевого пузыря
         if self.drag_mode == "move_tail" and self.tail_move_panel:
             p = self.tail_move_panel
-            root_x = (p.x + p.width / 2) * self.zoom + self.margin
-            root_y = (p.y + p.height)      * self.zoom + self.margin
-            p.tail_dx = event.x - root_x
-            p.tail_dy = event.y - root_y
+            root_angle = getattr(p, 'tail_root_angle', math.pi / 2)
+            cx = p.x + p.width / 2
+            cy = p.y + p.height / 2
+            root_px = cx + (p.width / 2) * math.cos(root_angle)
+            root_py = cy + (p.height / 2) * math.sin(root_angle)
+            cur_page_x, cur_page_y = self.screen_to_page(event.x, event.y)
+            p.tail_dx = cur_page_x - root_px
+            p.tail_dy = cur_page_y - root_py
+            p.mark_visuals_for_update()
+            self.redraw()
+            return
+
+        if self.drag_mode == "move_tail_root" and self.tail_root_move_panel:
+            p = self.tail_root_move_panel
+            cur_page_x, cur_page_y = self.screen_to_page(event.x, event.y)
+            cx = p.x + p.width / 2
+            cy = p.y + p.height / 2
+            angle = math.atan2((cur_page_y - cy) * p.width,
+                               (cur_page_x - cx) * p.height)
+            p.tail_root_angle = angle
+            root_px = cx + (p.width / 2) * math.cos(angle)
+            root_py = cy + (p.height / 2) * math.sin(angle)
+            p.tail_dx = self.tail_root_drag_end_x - root_px
+            p.tail_dy = self.tail_root_drag_end_y - root_py
             p.mark_visuals_for_update()
             self.redraw()
             return
@@ -1251,6 +1318,16 @@ class PageConstructor:
             self.redraw()
             return
 
+        if self.drag_mode == "move_tail_root":
+            self.save_history_state()
+            self.app.project_modified = True
+            self.app.update_title()
+            self.tail_root_move_panel = None
+            self.dragging = False
+            self.drag_mode = None
+            self.redraw()
+            return
+
         # 4-2. закончили создание новой панели
         if self.drag_mode == "create":
             spx, spy = self.snap_to_grid_coords(start_px, start_py)
@@ -1283,6 +1360,7 @@ class PageConstructor:
         self.resize_handle = None
         self.panel_drag_initial_states.clear()
         self.tail_move_panel = None
+        self.tail_root_move_panel = None
 
         self.redraw()
         


### PR DESCRIPTION
## Summary
- allow dragging speech bubble tail base and keep endpoint stable
- store tail base angle and draw bubble tail using tangent orientation
- enlarge export bounds for speech bubbles and render tails
- add offsets for image content during export

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_684df0973d6c8323ad04b8e0644b1efd